### PR TITLE
CAZB-1551 Retrofit API also has list of business and parse errors returned together

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,3 +107,10 @@ localstack-run:
 
 dependency-security-check:
 	./mvnw org.owasp:dependency-check-maven:check -P security
+
+local-integration-up:
+	docker-compose -f src/it/resources/docker-compose-it.yml up -d
+
+local-integration-down:
+	docker-compose -f src/it/resources/docker-compose-it.yml down
+

--- a/src/it/java/uk/gov/caz/retrofit/RegisterTestIT.java
+++ b/src/it/java/uk/gov/caz/retrofit/RegisterTestIT.java
@@ -107,7 +107,7 @@ public class RegisterTestIT {
 
   private StatusOfRegisterCsvFromS3JobQueryResult queryResult;
 
-  private RegisterCsvFromS3JobHandle jobHandle;
+  private volatile RegisterCsvFromS3JobHandle jobHandle;
 
   @Autowired
   private RegisterJobRepository registerJobRepository;

--- a/src/it/resources/data/csv/second-uploader-mixed-business-parse-errors.csv
+++ b/src/it/resources/data/csv/second-uploader-mixed-business-parse-errors.csv
@@ -1,0 +1,11 @@
+invalid-vrn,category-1,"model"",b",2019-04-30
+invalid-vrn,category-1,"model"",b",2019-04-30
+
+
+invalid-vrn,category-1,"model"",b",2019-04-30
+invalid-vrn,category-1,"model"",b",2019-04-30
+invalid-vrn,category-1,model-1,2019-03-12
+invalid-vrn,category-1,model-1,2019-03-12
+
+invalid-vrn,category-1,model-1,2019-03-12
+invalid-vrn,category-1,model-1,2019-03-12

--- a/src/main/java/uk/gov/caz/retrofit/service/RetrofittedVehicleDtoToModelConverter.java
+++ b/src/main/java/uk/gov/caz/retrofit/service/RetrofittedVehicleDtoToModelConverter.java
@@ -1,11 +1,9 @@
 package uk.gov.caz.retrofit.service;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
 import java.time.LocalDate;
-import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
 import uk.gov.caz.retrofit.dto.RetrofittedVehicleDto;
 import uk.gov.caz.retrofit.model.ConversionResult;
@@ -17,49 +15,18 @@ import uk.gov.caz.retrofit.model.ValidationError;
 public class RetrofittedVehicleDtoToModelConverter {
 
   /**
-   * Converts the passed list of {@link RetrofittedVehicleDto}s to {@link ConversionResults} with
-   * the respect to the total number of validation errors that occur while converting. If {@code
-   * maxErrorsCount} is zero, then no conversion takes place and an instance of {@link
-   * ConversionResults} is returned with empty vehicles and validation errors.
+   * Converts the passed list of {@link RetrofittedVehicleDto}s to {@link ConversionResults}.
    *
    * @param vehicles A list of {@link RetrofittedVehicleDto} which are to be mapped to a list of
    *     {@link RetrofittedVehicle} wrapped in {@link ConversionResults}.
-   * @param maxErrorsCount The total number of validation errors that can happen during the
-   *     conversion. If the size of validation errors reaches or exceeds this number the conversion
-   *     is stopped immediately and the list of validation errors is truncated to satisfy the
-   *     predicate: {@code ConversionResults.getValidationErrors().size() <= maxErrorsCount}.
    * @return An instance of {@link ConversionResults} which contains a list of converted vehicles
-   *     into vehicles and a list of validation errors whose size does not exceed {@code
-   *     maxErrorsCount} if {@code maxErrorsCount > 0}. If {@code maxErrorsCount == 0} an instance
-   *     of {@link ConversionResults} with with empty vehicles and validation errors is returned.
-   * @throws IllegalArgumentException if {@code maxErrorsCount < 0}.
+   *     into vehicles
    */
-  public ConversionResults convert(List<RetrofittedVehicleDto> vehicles, int maxErrorsCount) {
-    Preconditions.checkArgument(maxErrorsCount >= 0, "Expected maxErrorsCount >= 0, but %s < 0",
-        maxErrorsCount);
-
-    List<ConversionResult> conversionResults = Lists.newArrayListWithExpectedSize(vehicles.size());
-    Iterator<RetrofittedVehicleDto> it = vehicles.iterator();
-    int errorsCountLeft = maxErrorsCount;
-    while (errorsCountLeft > 0 && it.hasNext()) {
-      ConversionResult conversionResult = toRetrofittedVehicle(it.next());
-      if (conversionResult.isFailure()) {
-        conversionResult = truncateValidationErrorsToMatchLimit(errorsCountLeft, conversionResult);
-        errorsCountLeft -= conversionResult.getValidationErrors().size();
-      }
-      conversionResults.add(conversionResult);
-    }
+  public ConversionResults convert(List<RetrofittedVehicleDto> vehicles) {
+    List<ConversionResult> conversionResults = vehicles.stream()
+        .map(vehicle -> toRetrofittedVehicle(vehicle))
+        .collect(Collectors.toList());
     return ConversionResults.from(conversionResults);
-  }
-
-  private ConversionResult truncateValidationErrorsToMatchLimit(int errorsCountLeft,
-      ConversionResult conversionResult) {
-    List<ValidationError> validationErrors = conversionResult.getValidationErrors();
-    if (validationErrors.size() > errorsCountLeft) {
-      // assertion: validationErrors.size() > errorsCountLeft > 0
-      return ConversionResult.failure(validationErrors.subList(0, errorsCountLeft));
-    }
-    return conversionResult;
   }
 
   /**

--- a/src/test/java/uk/gov/caz/retrofit/service/RegisterFromCsvCommandTest.java
+++ b/src/test/java/uk/gov/caz/retrofit/service/RegisterFromCsvCommandTest.java
@@ -126,7 +126,7 @@ class RegisterFromCsvCommandTest {
         TestObjects.TYPICAL_REGISTER_JOB_UPLOADER_ID, vehicles, Collections.singletonList(parseValidationError)
     );
     given(csvRepository.findAll(any(), any())).willReturn(csvFindResult);
-    given(converter.convert(eq(vehicles), anyInt())).willReturn(ConversionResults.from(Collections.emptyList()));
+    given(converter.convert(eq(vehicles))).willReturn(ConversionResults.from(Collections.emptyList()));
     given(csvRepository.purgeFile(BUCKET, FILENAME)).willReturn(true);
 
     // when
@@ -144,7 +144,7 @@ class RegisterFromCsvCommandTest {
     CsvFindResult csvFindResult = new CsvFindResult(TestObjects.TYPICAL_REGISTER_JOB_UPLOADER_ID, vehicles, Collections.emptyList());
     ConversionResults conversionResults = ConversionResults.from(Collections.emptyList());
     given(csvRepository.findAll(any(), any())).willReturn(csvFindResult);
-    given(converter.convert(eq(vehicles), anyInt())).willReturn(conversionResults);
+    given(converter.convert(eq(vehicles))).willReturn(conversionResults);
     given(registerService.register(conversionResults.getRetrofittedVehicles(), TestObjects.TYPICAL_REGISTER_JOB_UPLOADER_ID)).willReturn(RegisterResult.failure(Collections.emptyList()));
     given(csvRepository.purgeFile(BUCKET, FILENAME)).willReturn(true);
 
@@ -164,7 +164,7 @@ class RegisterFromCsvCommandTest {
         vehicles, Collections.emptyList());
     ConversionResults conversionResults = ConversionResults.from(Collections.emptyList());
     given(csvRepository.findAll(any(), any())).willReturn(csvFindResult);
-    given(converter.convert(eq(vehicles), anyInt())).willReturn(conversionResults);
+    given(converter.convert(eq(vehicles))).willReturn(conversionResults);
     given(registerService.register(conversionResults.getRetrofittedVehicles(), TestObjects.TYPICAL_REGISTER_JOB_UPLOADER_ID))
         .willReturn(RegisterResult.failure(Collections.emptyList()));
     given(csvRepository.purgeFile(BUCKET, FILENAME)).willReturn(false);

--- a/src/test/java/uk/gov/caz/retrofit/service/RetrofittedVehicleDtoToModelConverterTest.java
+++ b/src/test/java/uk/gov/caz/retrofit/service/RetrofittedVehicleDtoToModelConverterTest.java
@@ -1,6 +1,5 @@
 package uk.gov.caz.retrofit.service;
 
-import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.BDDAssertions.then;
 
 import java.util.Arrays;
@@ -9,8 +8,6 @@ import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.caz.retrofit.dto.RetrofittedVehicleDto;
 import uk.gov.caz.retrofit.model.ConversionResult;
@@ -66,28 +63,10 @@ class RetrofittedVehicleDtoToModelConverterTest {
           createValidRetrofittedVehicle());
 
       // when
-      ConversionResults conversionResults = converter.convert(retrofittedVehicleDtos, UNLIMITED_ERROR_COUNT);
+      ConversionResults conversionResults = converter.convert(retrofittedVehicleDtos);
 
       // then
       then(conversionResults.hasValidationErrors()).isFalse();
-      then(conversionResults.getRetrofittedVehicles()).hasSize(1);
-    }
-
-    @Test
-    public void shouldConvertUpToPassedErrorThreshold() {
-      // given
-      int maxErrorCount = 3;
-      List<RetrofittedVehicleDto> vehicles = Arrays.asList(
-          createValidRetrofittedVehicle(),
-          createInvalidRetrofittedVehicleWithThreeAttributes(),
-          createInvalidRetrofittedVehicleWithTwoAttributes()
-      );
-
-      // when
-      ConversionResults conversionResults = converter.convert(vehicles, maxErrorCount);
-
-      // then
-      then(conversionResults.getValidationErrors()).hasSize(maxErrorCount);
       then(conversionResults.getRetrofittedVehicles()).hasSize(1);
     }
 
@@ -99,32 +78,13 @@ class RetrofittedVehicleDtoToModelConverterTest {
       );
 
       // when
-      ConversionResults conversionResults = converter.convert(retrofittedVehicleDtos, UNLIMITED_ERROR_COUNT);
+      ConversionResults conversionResults = converter.convert(retrofittedVehicleDtos);
 
       // then
       then(conversionResults.hasValidationErrors()).isTrue();
       then(conversionResults.getValidationErrors()).hasSize(1);
       then(conversionResults.getRetrofittedVehicles()).hasSize(1);
     }
-
-    @Test
-    public void shouldConvertAndTruncateErrorsToPassedErrorThreshold() {
-      // given
-      int maxErrorCount = 4;
-      // contains 5 validation errors in total
-      List<RetrofittedVehicleDto> licences = Arrays.asList(
-          createInvalidRetrofittedVehicleWithTwoAttributes(),
-          createInvalidRetrofittedVehicleWithThreeAttributes()
-      );
-
-      // when
-      ConversionResults conversionResults = converter.convert(licences, maxErrorCount);
-
-      // then
-      then(conversionResults.getValidationErrors()).hasSize(maxErrorCount);
-      then(conversionResults.getRetrofittedVehicles()).isEmpty();
-    }
-
     @Test
     public void shouldFlattenValidationErrorsFromMoreThanOneLicence() {
       // given
@@ -134,26 +94,13 @@ class RetrofittedVehicleDtoToModelConverterTest {
       );
 
       // when
-      ConversionResults conversionResults = converter.convert(retrofittedVehicleDtos, UNLIMITED_ERROR_COUNT);
+      ConversionResults conversionResults = converter.convert(retrofittedVehicleDtos);
 
       // then
       then(conversionResults.getValidationErrors()).hasSize(5);
       then(conversionResults.getRetrofittedVehicles()).isEmpty();
     }
 
-    @ParameterizedTest
-    @ValueSource(ints = {-1 -2, -15, -100})
-    public void shouldThrowIllegalArgumentExceptionIfErrorCountIsNegative(int maxErrorCount) {
-      // given
-      List<RetrofittedVehicleDto> licences = Collections.singletonList(
-          createInvalidRetrofittedVehicleWithTwoAttributes());
-
-      // when
-      Throwable throwable = catchThrowable(() -> converter.convert(licences, maxErrorCount));
-
-      // then
-      then(throwable).isInstanceOf(IllegalArgumentException.class);
-    }
   }
 
   private RetrofittedVehicleDto createValidRetrofittedVehicle() {


### PR DESCRIPTION
JIRA: https://eaflood.atlassian.net/browse/CAZB-1551
Previously we had list of parse errors and business given to user separately,
now we have one merged list, that is a subject to `max-validation-error` setting