### PR TITLE
[CAZB-3004] Alter the WHERE IN clause when deleting VRNs

### DIFF
--- a/src/test/java/uk/gov/caz/retrofit/repository/RetrofittedVehiclePostgresRepositoryTest.java
+++ b/src/test/java/uk/gov/caz/retrofit/repository/RetrofittedVehiclePostgresRepositoryTest.java
@@ -51,13 +51,10 @@ class RetrofittedVehiclePostgresRepositoryTest {
   @Mock
   private JdbcTemplate jdbcTemplate;
 
-  @Mock
-  private NamedParameterJdbcTemplate namedParameterJdbcTemplate;
-
   @BeforeEach
   void setup() {
     retrofittedVehiclePostgresRepository = new RetrofittedVehiclePostgresRepository(
-        jdbcTemplate, namedParameterJdbcTemplate, ANY_BATCH_SIZE
+        jdbcTemplate, ANY_BATCH_SIZE
     );
   }
 
@@ -94,6 +91,7 @@ class RetrofittedVehiclePostgresRepositoryTest {
     retrofittedVehiclePostgresRepository.delete(vrns);
 
     // then
-    verify(namedParameterJdbcTemplate, never()).update(anyString(), anyMap());
+    verify(jdbcTemplate, never()).execute(anyString());
+    verify(jdbcTemplate, never()).update(anyString());
   }
 }

--- a/src/test/java/uk/gov/caz/retrofit/service/RegisterServiceTest.java
+++ b/src/test/java/uk/gov/caz/retrofit/service/RegisterServiceTest.java
@@ -107,7 +107,7 @@ class RegisterServiceTest {
     private Set<RetrofittedVehicle> retrofittedVehicles = new HashSet<>();
 
     public InMemoryRetrofittedRepository() {
-      super(null, null, 2);
+      super(null, 2);
     }
 
     @Override


### PR DESCRIPTION
**The problem**
* Problematic scenario: The database has stored a large number of retrofitted VRNs. When trying to update the retrofit vehicles list with small amount of vehicles, the differential algorithm has to remove ONLY the VRNs which are not already stored in the database. So far it was achieved using the `DELETE FROM table WHERE vrn IN (?)`. The `WHERE IN` clause happens to be problematic for a large amount of data, and in the problematic scenario we were trying to delete in batches of 10k records.
* In order to keep the differential algorithm working and to reduce the time of execution, I made use of the temporary table mechanism from the PostgreSQL [(article)](https://www.baeldung.com/spring-jdbctemplate-in-list#large)
* With the temporary table solution, deleting VRNs in batches is no longer required, as we do not explicitly insert VRNs into the `WHERE IN` clause